### PR TITLE
ssr: Fix building due the missing surround_rec_interface.h

### DIFF
--- a/hal/Android.mk
+++ b/hal/Android.mk
@@ -125,6 +125,9 @@ endif
 
 ifeq ($(strip $(AUDIO_FEATURE_ENABLED_SSR)),true)
     LOCAL_CFLAGS += -DSSR_ENABLED
+    ifeq ($(QCPATH),)
+        LOCAL_CFLAGS += -D_OSS
+    endif
     LOCAL_SRC_FILES += audio_extn/ssr.c
     LOCAL_C_INCLUDES += $(TARGET_OUT_HEADERS)/mm-audio/surround_sound_3mic/
     LOCAL_C_INCLUDES += $(TARGET_OUT_HEADERS)/common/inc/

--- a/hal/audio_extn/ssr.c
+++ b/hal/audio_extn/ssr.c
@@ -36,7 +36,19 @@
 #include "audio_extn.h"
 #include "platform.h"
 #include "platform_api.h"
+#ifndef _OSS
 #include "surround_rec_interface.h"
+#else
+typedef struct {
+    const char *name;
+    char *(*get_param_fn)(void *h);
+} get_param_data_t;
+
+typedef struct {
+    const char *name;
+    void (*set_param_fn)(void *h, const char *val);
+} set_param_data_t;
+#endif
 
 #ifdef DYNAMIC_LOG_ENABLED
 #include <log_xml_parser.h>


### PR DESCRIPTION
Apply the following commit: https://github.com/LineageOS/android_hardware_qcom_audio/commit/afa808a5db2d5a1b93e06d54431cdee127afdc74


type -MD -MF /home/novalineageos/LOS15/out/target/product/hwcan/obj_arm/SHARED_LIBRARIES/audio.primary.msm8953_intermediates/audio_extn/ssr.d -o /home/novalineageos/LOS15/out/target/product/hwcan/obj_arm/SHARED_LIBRARIES/audio.primary.msm8953_intermediates/audio_extn/ssr.o hardware/qcom/audio-caf/msm8996/hal/audio_extn/ssr.c"
[1mhardware/qcom/audio-caf/msm8996/hal/audio_extn/ssr.c:39:10: [0m[0;1;31mfatal error: [0m[1m'surround_rec_interface.h' file not found[0m
#include "surround_rec_interface.h"
[0;1;32m         ^~~~~~~~~~~~~~~~~~~~~~~~~~
[0m1 error generated.