### PR TITLE
msm8916: Fix build by removing unused variable

### DIFF
--- a/hal/msm8916/platform.c
+++ b/hal/msm8916/platform.c
@@ -4397,7 +4397,6 @@ static int set_hd_voice(struct platform_data *my_data, bool state)
 int platform_set_parameters(void *platform, struct str_parms *parms)
 {
     struct platform_data *my_data = (struct platform_data *)platform;
-    struct audio_device *adev = my_data->adev;
     char value[256] = {0};
     int len;
     int ret = 0, err;


### PR DESCRIPTION
adev is unused in this scope so remove it to fix build warnings/errors.